### PR TITLE
Added condition for bastion module call

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,6 +130,8 @@ resource "aws_key_pair" "bastion" {
 }
 
 module "bastion" {
+  count = var.bastion_host_enabled ? 1 : 0
+
   source  = "cloudposse/ec2-bastion-server/aws"
   version = "0.30.1"
 


### PR DESCRIPTION
I added the `count = var.bastion_host_enabled ? 1 : 0` condition to the `bastion` module call, as it should only be called when someone is using our Isovalent VPC module with `var.bastion_host_enabled=true` (default is `false`).
I don't see any further places where this change could have an impact. In the `outputs.tf` `[*]` is already used when accessing `module.bastion`.

Background: I get the following error when using the Isovalent VPC Terraform module:
```
│ Error: Invalid index
│
│   on .terraform/modules/vpc/main.tf line 138, in module "bastion":
│  138:   key_name                    = aws_key_pair.bastion[0].key_name
│     ├────────────────
│     │ aws_key_pair.bastion is empty tuple
│
│ The given key does not identify an element in this collection value: the collection has no elements.
```

My `vpc/main.tf`:
```
// Get all availability zones for the current region.
data "aws_availability_zones" "available" {
  state = "available"
}

// Create the VPC.
module "vpc" {
  source = "git::ssh://git@github.com/isovalent/terraform-aws-vpc.git?ref=v1.2"

  cidr   = var.vpc_cidr
  name   = var.cluster_name
  region = var.region
  tags   = local.tags
}
```