### PR TITLE
Add additional_private_subnets_cidr_blocks output

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ An opinionated Terraform module that can be used to create and manage an VPC in 
 | Name | Description |
 |------|-------------|
 | <a name="output_additional_private_subnet_ids"></a> [additional\_private\_subnet\_ids](#output\_additional\_private\_subnet\_ids) | The IDs of the additional private subnets that have been created. |
+| <a name="output_additional_private_subnets_cidr_blocks"></a> [additional\_private\_subnets\_cidr\_blocks](#output\_additional\_private\_subnets\_cidr\_blocks) | The additional private subnets that have been created. |
 | <a name="output_additional_public_subnet_ids"></a> [additional\_public\_subnet\_ids](#output\_additional\_public\_subnet\_ids) | The IDs of the additional public subnets that have been created. |
 | <a name="output_bastion_host_private_ip"></a> [bastion\_host\_private\_ip](#output\_bastion\_host\_private\_ip) | n/a |
 | <a name="output_bastion_host_public_ip"></a> [bastion\_host\_public\_ip](#output\_bastion\_host\_public\_ip) | n/a |

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,13 @@ output "additional_private_subnet_ids" {
   ]
 }
 
+output "additional_private_subnets_cidr_blocks" {
+  description = "The additional private subnets that have been created."
+  value = [
+    for k, v in aws_subnet.additional_private_subnets : v.cidr_block
+  ]
+}
+
 output "additional_public_subnet_ids" {
   description = "The IDs of the additional public subnets that have been created."
   value = [


### PR DESCRIPTION
This commit adds the following output:
 - additional_private_subnets_cidr_blocks

which makes it easier to double check the egress gw IPs.