### PR TITLE
Add GHAs to check formatting and docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    rebase-strategy: "disabled"
+    labels:
+      - ci/dependabot
+      - kind/enhancement

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,36 @@
+name: Terraform docs and formatting
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - master
+jobs:
+  formatting:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: terraform fmt
+        uses: dflook/terraform-fmt-check@fc6a4d63e251c5d6f247fc8310171a4e45e18210
+  docs:
+    needs: formatting
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Render terraform docs inside the README.md and push changes back to PR branch
+        uses: terraform-docs/gh-actions@cfde42f79b15256c71f4b79ae1d6acea0f689952
+        with:
+          working-dir: .
+          output-file: README.md
+          output-method: inject
+          output-format: markdown table
+          git-push: "true"


### PR DESCRIPTION
This commit adds GHAs to check the formatting of Terraform files. On top, it adds a way of checking whether the make docs command was run to update the docs.