### PR TITLE
enable ipv6 for the VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ An opinionated Terraform module that can be used to create and manage an VPC in 
 | <a name="input_bastion_host_security_group_rules"></a> [bastion\_host\_security\_group\_rules](#input\_bastion\_host\_security\_group\_rules) | A list of security group rules to apply to the bastion host. | `list(any)` | `[]` | no |
 | <a name="input_bastion_host_ssh_public_key"></a> [bastion\_host\_ssh\_public\_key](#input\_bastion\_host\_ssh\_public\_key) | If specified, will be used as the public SSH key for the bastion host. | `string` | `""` | no |
 | <a name="input_cidr"></a> [cidr](#input\_cidr) | The CIDR to be used for the VPC. | `string` | n/a | yes |
+| <a name="input_enable_ipv6"></a> [enable\_ipv6](#input\_enable\_ipv6) | Whether to enable the ipv6 stack. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the VPC. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region in which to create the VPC. | `string` | n/a | yes |
 | <a name="input_secondary_cidr_blocks"></a> [secondary\_cidr\_blocks](#input\_secondary\_cidr\_blocks) | List of secondary CIDR blocks to use. | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,10 @@ module "vpc" {
   single_nat_gateway     = true                                        // Use a single NAT gateway as that's the simplest and also all we need.
   tags                   = var.tags                                    // Use the tags specified as a variable.
 
+  enable_ipv6                                    = var.enable_ipv6 // this will provide Amazon-provided IPv6 CIDR block which is a /56 block
+  public_subnet_assign_ipv6_address_on_creation  = var.enable_ipv6 // this will help the EC2 to get the IPV6 address when it boots
+  private_subnet_assign_ipv6_address_on_creation = var.enable_ipv6 // this will help the EC2 to get the IPV6 address when it boots
+
   // Create one private subnet per AZ (e.g. "10.1.0.0/24", "10.1.1.0/24", "10.1.2.0/24", ...).
   // This could surely have been made differently (possibly even sourced from a variable), but it suffices for the time being.
   private_subnets = [
@@ -63,6 +67,16 @@ module "vpc" {
       "type"                   = "public" // Required by AWS Load Balancer controller.
     },
   )
+  //This is needed when enabling the IPV6 but will not hurt when the IPV6 is not enabled.
+  private_subnet_ipv6_prefixes = [
+    for i, v in data.aws_availability_zones.available.names :
+    i
+  ]
+  public_subnet_ipv6_prefixes = [
+    for i, v in data.aws_availability_zones.available.names :
+    10 + i
+  ]
+
 }
 
 // Used to wait for the secondary CIDRs to be listed, as otherwise the AWS API will *sometimes* throw errors.

--- a/variables.tf
+++ b/variables.tf
@@ -124,3 +124,9 @@ variable "tags" {
   description = "The tags to place on the VPC."
   type        = map(string)
 }
+
+variable "enable_ipv6" {
+  default     = false
+  description = "Whether to enable the ipv6 stack."
+  type        = bool
+}


### PR DESCRIPTION
enable the IPV6 for VPC and subnets and create the new var to enable the IPV6 so it will be dual stack VPC and will be compatible with the dual stack K8S