### PR TITLE
chore: Bump the vpc dependency to 5.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ An opinionated Terraform module that can be used to create and manage an VPC in 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_bastion"></a> [bastion](#module\_bastion) | cloudposse/ec2-bastion-server/aws | 0.31.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 5.0.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 5.15.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "aws_availability_zones" "available" {
 // The VPC itself, as well as main subnets.
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "5.0.0"
+  version = "5.15.0"
 
   azs                     = local.availability_zones    // Use selected availability zones.
   cidr                    = var.cidr                    // Use the CIDR specified as a variable.


### PR DESCRIPTION
This fixes issues with the provisioning of dual-stack networking. With the previous version the same IPv6 route for egress was added multiple times to the same routing table and failing instead of adding it to a routing table specific to each az.