### PR TITLE
Enforce access_ip_addresses only when bastion host is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ An opinionated Terraform module that can be used to create and manage an VPC in 
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_access_ip_addresses"></a> [access\_ip\_addresses](#input\_access\_ip\_addresses) | The list of IP address specified will be able to access the bastion. | `list(string)` | n/a | yes |
+| <a name="input_access_ip_addresses"></a> [access\_ip\_addresses](#input\_access\_ip\_addresses) | The list of IP address specified will be able to access the bastion. | `list(string)` | `[]` | no |
 | <a name="input_additional_private_subnet_tags"></a> [additional\_private\_subnet\_tags](#input\_additional\_private\_subnet\_tags) | Additional tags for the private subnets | `map(string)` | `{}` | no |
 | <a name="input_additional_private_subnets"></a> [additional\_private\_subnets](#input\_additional\_private\_subnets) | Additional private subnets to create. | <pre>list(object({<br/>    availability_zone = string<br/>    cidr              = string<br/>    tags              = map(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_additional_public_subnet_tags"></a> [additional\_public\_subnet\_tags](#input\_additional\_public\_subnet\_tags) | Additional tags for the public subnets | `map(string)` | `{}` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -98,8 +98,13 @@ variable "bastion_host_security_group_rules" {
 }
 
 variable "access_ip_addresses" {
+  default     = []
   description = "The list of IP address specified will be able to access the bastion."
   type        = list(string)
+  validation {
+    condition     = !var.bastion_host_enabled || length(var.access_ip_addresses) > 0
+    error_message = "At least one IP address must be specified when bastion host is enabled."
+  }
 }
 
 variable "bastion_host_instance_type" {


### PR DESCRIPTION
As the SG is only created in case a Bastion host is deployed.

~~Still need to test it.~~

* If `bastion_host_enabled` is `false`
  * `!false` → `true` → validation succeeds no matter what the `access_ip_addresses` list contains.
* If `bastion_host_enabled` is `true`
  * `!true` → `false`, so Terraform now checks the right-hand side:
    * If the `access_ip_addresses` list is empty (`length == 0`) ⇒ `false || false` → `false` → validation fails and the run stops with the error message.
    * If the `access_ip_addresses` list has at least one element (`length > 0`) ⇒ `false || true` → `true` → validation passes.