### PR TITLE
Bastion: Fix shadowed security group rules

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -3,7 +3,7 @@ locals {
   availability_zones         = length(var.availability_zones) > 0 ? var.availability_zones : data.aws_availability_zones.available.names
   bastion_host_security_group_rules = [
     {
-      "cidr_blocks" : var.access_ip_addresses,
+      "cidr_blocks" : ["0.0.0.0/0"],
       "description" : "Allow all outbound traffic",
       "from_port" : 0,
       "protocol" : -1,

--- a/main.tf
+++ b/main.tf
@@ -166,7 +166,7 @@ module "bastion" {
   key_name                    = aws_key_pair.bastion[0].key_name
   name                        = "${var.name}-bastion"
   security_groups             = var.bastion_host_extra_security_groups
-  security_group_rules        = local.bastion_host_security_group_rules
+  security_group_rules        = concat(local.bastion_host_security_group_rules, var.bastion_host_security_group_rules)
   ssm_enabled                 = true
   subnets                     = var.bastion_host_assign_public_ip ? module.vpc.public_subnets : module.vpc.private_subnets
   tags                        = var.tags


### PR DESCRIPTION
We forgot to concat the existing security group
rules in the locals with the variables. variables
were shadowed by the locals.