### PR TITLE
update the SG ingress logic

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -102,7 +102,7 @@ variable "access_ip_addresses" {
   description = "The list of IP address specified will be able to access the bastion."
   type        = list(string)
   validation {
-    condition     = !var.bastion_host_enabled || length(var.access_ip_addresses) > 0
+    condition     = !contains(var.access_ip_addresses, "0.0.0.0/0")
     error_message = "At least one IP address must be specified when bastion host is enabled."
   }
 }


### PR DESCRIPTION
tf doesn't allow var to validate with other vars.
so we can only check if ip address has 0.0.0.0/0. I think that's enough because if we dont have bastin then we dont care about it.


fixing https://github.com/isovalent/terraform-aws-vpc/issues/67