### PR TITLE
Bump VPC upstream module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,22 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 5
     rebase-strategy: "disabled"
     labels:
       - ci/dependabot
       - kind/enhancement
+    ignore:
+      - dependency-name: "hashicorp/aws"
+        update-types: 
+        - "version-update:semver-minor"
+        - "version-update:semver-patch"
+      - dependency-name: "hashicorp/null"
+        update-types: 
+        - "version-update:semver-minor"
+        - "version-update:semver-patch"
+      - dependency-name: "hashicorp/tls"
+        update-types: 
+        - "version-update:semver-minor"
+        - "version-update:semver-patch"

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ data "aws_availability_zones" "available" {
 // The VPC itself, as well as main subnets.
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "5.15.0"
+  version = "6.0.1"
 
   azs                     = local.availability_zones    // Use selected availability zones.
   cidr                    = var.cidr                    // Use the CIDR specified as a variable.

--- a/terraform.tf
+++ b/terraform.tf
@@ -16,16 +16,16 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.31.0"
+      version = "~> 6.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = ">= 3.1.1"
+      version = "~> 3.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "< 4.0.0"
+      version = "~> 4.0"
     }
   }
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Bump terraform-aws-modules/vpc/aws to 6.0.1

Adjust dependabot logic

This commit sets the version filter of modules
in the terraform.tf to a major version. It also
adjusts the dependabot configuration to check
for major updates only weekly.